### PR TITLE
Support vhdl2008

### DIFF
--- a/CommandRef.md
+++ b/CommandRef.md
@@ -16,6 +16,8 @@ namespace import psi::ip_package::latest::*
 * Configuration Commands
  * [set_description](#set_description) 
  * [set_vendor](#set_vendor) 
+ * [set_vendor_short](#set_vendor_short)
+ * [set_vendor_url](#set_vendor_url)
  * [set_logo_relative](#set_logo_relative) 
  * [set_datasheet_relative](#set_datasheet_relative)
  * [set_top_entity](#set_top_entity)
@@ -131,6 +133,62 @@ fully reverse compatible.
       <td> vendor </td>
       <td> No </td>
       <td> Vendor of the IP-Core </td>
+    </tr>
+</table>
+
+### set_vendor_short
+**Usage**
+
+```
+set_vendor_short <vendor>
+```
+
+**Description**
+
+Set the vendor abbreviation of the IP-Core that is shown in Vivado. Note that hte vendor abbreviation is not allowed to contain any whitespaces.
+
+This command is optional. If it is not used, the vendor abbreviation is set to \"psi.ch\". This is chosen this way to make the code
+fully reverse compatible.
+
+**Parameters**
+<table>
+    <tr>
+      <th width="200"><b>Parameter</b></th>
+      <th align="center" width="80"><b>Optional</b></th>
+      <th align="right"><b>Description</b></th>
+    </tr>
+    <tr>
+      <td> vendor </td>
+      <td> No </td>
+      <td> Vendor abbreviation (no whitespaces allowed) </td>
+    </tr>
+</table>
+
+### set_vendor_url
+**Usage**
+
+```
+set_vendor_url <url>
+```
+
+**Description**
+
+Set the vendor URL of the IP-Core that is shown in Vivado.
+
+This command is optional. If it is not used, the vendor url is set to \"www.psi.ch\". This is chosen this way to make the code
+fully reverse compatible.
+
+**Parameters**
+<table>
+    <tr>
+      <th width="200"><b>Parameter</b></th>
+      <th align="center" width="80"><b>Optional</b></th>
+      <th align="right"><b>Description</b></th>
+    </tr>
+    <tr>
+      <td> url </td>
+      <td> No </td>
+      <td> Vendor URL of the IP-Core </td>
     </tr>
 </table>
 

--- a/CommandRef.md
+++ b/CommandRef.md
@@ -281,7 +281,7 @@ referenced relatively because usually IP-Cores are delivered as GIT repository a
 
 By default all files are compiled into a library named accoding to the IP-Core name and version but the user can optionally choose a different library using the *lib* parameter. 
 
-By default the file type is determined by Vivado automatically. However, in some cases this fails (e.g. VHDL 2008 is not recognized, Vivado assumed VHDL 2002). In these cases it is useful to explicitly set the file type (e.g. to "VHDL 2008").
+By default the file type is determined by Vivado automatically but the auto detected type can be overwritten manually. For VHDL, VHDL 2008 is used by default.
 
 **Parameters**
 <table>
@@ -322,7 +322,7 @@ copy the library files into the IP-Core, use [add_lib_copied](add_lib_copied) .
 
 By default all files are compiled into a library named accoding to the IP-Core name and version but the user can optionally choose a different library using the *lib* parameter.
 
-By default the file type is determined by Vivado automatically. However, in some cases this fails (e.g. VHDL 2008 is not recognized, Vivado assumed VHDL 2002). In these cases it is useful to explicitly set the file type (e.g. to "VHDL 2008").
+By default the file type is determined by Vivado automatically but the auto detected type can be overwritten manually. For VHDL, VHDL 2008 is used by default.
 
 **Parameters**
 
@@ -370,7 +370,7 @@ they represent.
 
 By default all files are compiled into a library named accoding to the IP-Core name and version but the user can optionally choose a different library using the *lib* parameter.
 
-By default the file type is determined by Vivado automatically. However, in some cases this fails (e.g. VHDL 2008 is not recognized, Vivado assumed VHDL 2002). In these cases it is useful to explicitly set the file type (e.g. to "VHDL 2008").
+By default the file type is determined by Vivado automatically but the auto detected type can be overwritten manually. For VHDL, VHDL 2008 is used by default.
 
 **Parameters**
 <table>

--- a/CommandRef.md
+++ b/CommandRef.md
@@ -271,7 +271,7 @@ Usually Vivado automatically detects the top entity name. If this works, the com
 **Usage**
 
 ```
-add_sources_relative <srcs> <lib>
+add_sources_relative <srcs> <lib> <type>
 ```
 
 **Description**
@@ -279,7 +279,9 @@ add_sources_relative <srcs> <lib>
 Add one or more source files to the IP-Core. Note that the source files are not copied into the IP-Core but
 referenced relatively because usually IP-Cores are delivered as GIT repository and already contain the sources.
 
-By default all files are compiled into a library named accoding to the IP-Core name and version but the user can optionally choose a different library using the *lib* parameter.
+By default all files are compiled into a library named accoding to the IP-Core name and version but the user can optionally choose a different library using the *lib* parameter. 
+
+By default the file type is determined by Vivado automatically. However, in some cases this fails (e.g. VHDL 2008 is not recognized, Vivado assumed VHDL 2002). In these cases it is useful to explicitly set the file type (e.g. to "VHDL 2008").
 
 **Parameters**
 <table>
@@ -296,7 +298,12 @@ By default all files are compiled into a library named accoding to the IP-Core n
     <tr>
       <td> lib </td>
       <td> Yes </td>
-      <td> VHDL library to compile the files into, default*<ip_name>_<ip_version>* if ths parameter is omitted </td>
+      <td> VHDL library to compile the files into, default*<ip_name>_<ip_version>* if ths parameter is omitted or "NONE" is passed. </td>
+    </tr>
+    <tr>
+      <td> type </td>
+      <td> Yes </td>
+      <td> Vivado file type. By default, the file type is detected automatically. Automatic detection can also be achieved by passing "NONE". </td>
     </tr>
 </table>
 
@@ -304,7 +311,7 @@ By default all files are compiled into a library named accoding to the IP-Core n
 **Usage**
 
 ```
-add_lib_relative <libPath> <files> <lib>
+add_lib_relative <libPath> <files> <lib> <type>
 ```
 
 **Description**
@@ -314,6 +321,8 @@ just links them using relative paths. As a result, in every project its own vers
 copy the library files into the IP-Core, use [add_lib_copied](add_lib_copied) .
 
 By default all files are compiled into a library named accoding to the IP-Core name and version but the user can optionally choose a different library using the *lib* parameter.
+
+By default the file type is determined by Vivado automatically. However, in some cases this fails (e.g. VHDL 2008 is not recognized, Vivado assumed VHDL 2002). In these cases it is useful to explicitly set the file type (e.g. to "VHDL 2008").
 
 **Parameters**
 
@@ -336,7 +345,12 @@ By default all files are compiled into a library named accoding to the IP-Core n
     <tr>
       <td> lib </td>
       <td> Yes </td>
-      <td> VHDL library to compile the files into, default*<ip_name>_<ip_version>* if ths parameter is omitted </td>
+      <td> VHDL library to compile the files into, default*<ip_name>_<ip_version>* if ths parameter is omitted or "NONE" is passed. </td>
+    </tr>
+    <tr>
+      <td> type </td>
+      <td> Yes </td>
+      <td> Vivado file type. By default, the file type is detected automatically. Automatic detection can also be achieved by passing "NONE". </td>
     </tr>
 </table>
 
@@ -344,7 +358,7 @@ By default all files are compiled into a library named accoding to the IP-Core n
 **Usage**
 
 ```
-add_lib_copied <tgtPath> <libPath> <files> <lib>
+add_lib_copied <tgtPath> <libPath> <files> <lib> <type>
 ```
 
 **Description**
@@ -355,6 +369,8 @@ files are delivered as part of the IP-Core and it is not possible to easily find
 they represent.
 
 By default all files are compiled into a library named accoding to the IP-Core name and version but the user can optionally choose a different library using the *lib* parameter.
+
+By default the file type is determined by Vivado automatically. However, in some cases this fails (e.g. VHDL 2008 is not recognized, Vivado assumed VHDL 2002). In these cases it is useful to explicitly set the file type (e.g. to "VHDL 2008").
 
 **Parameters**
 <table>
@@ -381,7 +397,12 @@ By default all files are compiled into a library named accoding to the IP-Core n
     <tr>
       <td> lib </td>
       <td> Yes </td>
-      <td> VHDL library to compile the files into, default*<ip_name>_<ip_version>* if ths parameter is omitted </td>
+      <td> VHDL library to compile the files into, default*<ip_name>_<ip_version>* if ths parameter is omitted or "NONE" is passed. </td>
+    </tr>
+    <tr>
+      <td> type </td>
+      <td> Yes </td>
+      <td> Vivado file type. By default, the file type is detected automatically. Automatic detection can also be achieved by passing "NONE". </td>
     </tr>
 </table>
 

--- a/IpPackage2017_2_1.tcl
+++ b/IpPackage2017_2_1.tcl
@@ -139,8 +139,12 @@ namespace export set_datasheet_relative
 # Add source files that are referenced to relatively
 #
 # @param srcs		List containing the source file paths relative to execution director
-# @param lib		VHDL library to copile files into (optional, default is <ip_name>_<ip_version>)
-proc add_sources_relative {srcs {lib "NONE"}} {
+# @param lib		VHDL library to copile files into (optional, default is <ip_name>_<ip_version>).
+#					"NONE" can be used to compile the files into the default library.
+# @param type		Vivado file type (common values "VHDL" or "VHDL 2008". If "NONE" is passed, vivado detects
+#					file type automatically. However, for VHDL 2008 this option must be used explicitly (vivado
+#					auto detection fails).
+proc add_sources_relative {srcs {lib "NONE"} {type "NONE"}} {
 	variable SrcRelative 
 	variable DefaultVhdlLib
 	variable srcFile [dict create]
@@ -151,6 +155,7 @@ proc add_sources_relative {srcs {lib "NONE"}} {
 		} else {
 			dict set srcFile LIBRARY $lib
 		}
+		dict set srcFile TYPE $type
 		lappend SrcRelative $srcFile
 	}
 }
@@ -180,7 +185,11 @@ namespace export add_drivers_relative
 # @param libPath	Relative path to the common library director of all files 
 # @param files		List containing the file paths within the library
 # @param lib		VHDL library to copile files into (optional, default is <ip_name>_<ip_version>)
-proc add_lib_relative {libPath files {lib "NONE"}} {
+#					"NONE" can be used to compile the files into the default library.
+# @param type		Vivado file type (common values "VHDL" or "VHDL 2008". If "NONE" is passed, vivado detects
+#					file type automatically. However, for VHDL 2008 this option must be used explicitly (vivado
+#					auto detection fails).
+proc add_lib_relative {libPath files {lib "NONE"} {type "NONE"}} {
 	variable LibRelative
 	variable DefaultVhdlLib
 	foreach file $files {
@@ -191,6 +200,7 @@ proc add_lib_relative {libPath files {lib "NONE"}} {
 		} else {
 			dict set libFile LIBRARY $lib
 		}
+		dict set libFile TYPE $type
 		lappend LibRelative $libFile
 	}
 }
@@ -202,7 +212,11 @@ namespace export add_lib_relative
 # @param libPath	Relative path to the common library director of all files 
 # @param files		List containing the file paths within the library directory
 # @param lib		VHDL library to copile files into (optional, default is <ip_name>_<ip_version>)
-proc add_lib_copied {tgtPath libPath files {lib "NONE"}} {
+#					"NONE" can be used to compile the files into the default library.
+# @param type		Vivado file type (common values "VHDL" or "VHDL 2008". If "NONE" is passed, vivado detects
+#					file type automatically. However, for VHDL 2008 this option must be used explicitly (vivado
+#					auto detection fails).
+proc add_lib_copied {tgtPath libPath files {lib "NONE"} {type "NONE"}} {
 	variable LibCopied
 	variable DefaultVhdlLib
 	foreach file $files {
@@ -214,6 +228,7 @@ proc add_lib_copied {tgtPath libPath files {lib "NONE"}} {
 		} else {
 			dict set copied LIBRARY $lib
 		}
+		dict set copied TYPE $type
 		lappend LibCopied $copied
 	}
 }
@@ -392,6 +407,10 @@ proc package {tgtDir {edit false} {synth false} {part ""}} {
 			puts $thisfile
 			add_files -norecurse $thisfile
 			set_property library [dict get $file LIBRARY] [get_files $thisfile]
+			variable fileType [dict get $file TYPE]
+			if {$fileType != "NONE"} {
+				set_property file_type $fileType [get_files $thisfile]
+			}
 		}
 	}
 	puts "*** Add relative library files to Project ***"
@@ -401,6 +420,10 @@ proc package {tgtDir {edit false} {synth false} {part ""}} {
 			puts $thisfile
 			add_files -norecurse $thisfile
 			set_property library [dict get $file LIBRARY] [get_files $thisfile]
+			variable fileType [dict get $file TYPE]
+			if {$fileType != "NONE"} {
+				set_property file_type $fileType [get_files $thisfile]
+			}
 		}		
 	}
 	
@@ -418,6 +441,10 @@ proc package {tgtDir {edit false} {synth false} {part ""}} {
 			file copy -force $srcPath $tgtPath
 			add_files -norecurse $tgtPath
 			set_property library [dict get $copied LIBRARY] [get_files $tgtPath]
+			variable fileType [dict get $file TYPE]
+			if {$fileType != "NONE"} {
+				set_property file_type $fileType [get_files $tgtPath]
+			}
 		}
 	}
 	

--- a/IpPackage2017_2_1.tcl
+++ b/IpPackage2017_2_1.tcl
@@ -21,6 +21,8 @@ variable IpRevision
 variable IpName 
 variable IpLibrary
 variable IpVendor
+variable IpVendorShort
+variable IpVendorUrl
 variable IpDescription
 variable SrcRelative
 variable LibRelative
@@ -55,6 +57,8 @@ proc init {name version revision library} {
 	}	
 	variable IpLibrary $library
 	variable IpVendor "Paul Scherrer Institute"
+	variable IpVendorUrl "http://www.psi.ch"
+	variable IpVendorShort "psi.ch"
 	variable IpVersionUnderscore
 	regsub -all {\.} $version {_} IpVersionUnderscore; list
 	variable SrcRelative [list]
@@ -91,6 +95,22 @@ proc set_vendor {vendor} {
 	variable IpVendor $vendor
 }
 namespace export set_vendor
+
+# Set the vendor abbreviation of the IP-Core
+#
+# @param vendor		Vendor abbreviation (must contain no whitespaces)
+proc set_vendor_short {vendor} {
+	variable IpVendorShort $vendor
+}
+namespace export set_vendor_short
+
+# Set the vendor URL of the IP-Core
+#
+# @param url		Vendor URL
+proc set_vendor_url {url} {
+	variable IpVendorUrl $url
+}
+namespace export set_vendor_url
 
 # Set the name of the top-entity (only required if Vivado cannot determine the top entity automatically)
 #
@@ -414,18 +434,20 @@ proc package {tgtDir {edit false} {synth false} {part ""}} {
 	variable IpVersion 
 	variable IpName
 	variable IpVendor
+	variable IpVendorShort
+	variable IpVendorUrl
 	variable DefaultVhdlLib
 	puts "*** Set IP properties ***"
 	#Having unreferenced files is not allowed (leads to problems in the script). Therefore the warning is promoted to an error.
 	set_msg_config -id  {[IP_Flow 19-3833]} -new_severity "ERROR"
 	ipx::package_project -root_dir $tgtDir -taxonomy /UserIP
-	set_property vendor "psi.ch" [ipx::current_core]
+	set_property vendor $IpVendorShort [ipx::current_core]
 	set_property name $IpName [ipx::current_core]
 	set_property library $IpLibrary [ipx::current_core]
 	set_property display_name $DefaultVhdlLib [ipx::current_core]
 	set_property description $IpDescription [ipx::current_core]
 	set_property vendor_display_name $IpVendor [ipx::current_core]
-	set_property company_url "http://www.psi.ch" [ipx::current_core]
+	set_property company_url $IpVendorUrl [ipx::current_core]
 	set_property version $IpVersion [ipx::current_core]
 	set_property supported_families {	artix7 Production virtex7 Beta qvirtex7 Beta kintex7 Beta kintex7l Beta qkintex7 Beta qkintex7l \
 										Beta artix7 Beta artix7l Beta aartix7 Beta qartix7 Beta zynq Beta qzynq Beta azynq Beta spartan7 Beta \

--- a/IpPackage2017_2_1.tcl
+++ b/IpPackage2017_2_1.tcl
@@ -141,9 +141,7 @@ namespace export set_datasheet_relative
 # @param srcs		List containing the source file paths relative to execution director
 # @param lib		VHDL library to copile files into (optional, default is <ip_name>_<ip_version>).
 #					"NONE" can be used to compile the files into the default library.
-# @param type		Vivado file type (common values "VHDL" or "VHDL 2008". If "NONE" is passed, vivado detects
-#					file type automatically. However, for VHDL 2008 this option must be used explicitly (vivado
-#					auto detection fails).
+# @param type		Override file type detected by vivado automatically. For VHDL, VHDL 2008 is used by default.
 proc add_sources_relative {srcs {lib "NONE"} {type "NONE"}} {
 	variable SrcRelative 
 	variable DefaultVhdlLib
@@ -155,7 +153,11 @@ proc add_sources_relative {srcs {lib "NONE"} {type "NONE"}} {
 		} else {
 			dict set srcFile LIBRARY $lib
 		}
+		#Use VHDL 2008 as default for all VHDL files
 		dict set srcFile TYPE $type
+		if {([string match "*.vhdl" $file] || [string match "*.vhd" $file]) && ($type == "NONE")} {
+			dict set srcFile TYPE "VHDL 2008"
+		}
 		lappend SrcRelative $srcFile
 	}
 }
@@ -186,9 +188,7 @@ namespace export add_drivers_relative
 # @param files		List containing the file paths within the library
 # @param lib		VHDL library to copile files into (optional, default is <ip_name>_<ip_version>)
 #					"NONE" can be used to compile the files into the default library.
-# @param type		Vivado file type (common values "VHDL" or "VHDL 2008". If "NONE" is passed, vivado detects
-#					file type automatically. However, for VHDL 2008 this option must be used explicitly (vivado
-#					auto detection fails).
+# @param type		Override file type detected by vivado automatically. For VHDL, VHDL 2008 is used by default.
 proc add_lib_relative {libPath files {lib "NONE"} {type "NONE"}} {
 	variable LibRelative
 	variable DefaultVhdlLib
@@ -200,7 +200,11 @@ proc add_lib_relative {libPath files {lib "NONE"} {type "NONE"}} {
 		} else {
 			dict set libFile LIBRARY $lib
 		}
+		#Use VHDL 2008 as default for all VHDL files
 		dict set libFile TYPE $type
+		if {([string match "*.vhdl" $file] || [string match "*.vhd" $file]) && ($type == "NONE")} {
+			dict set libFile TYPE "VHDL 2008"
+		}
 		lappend LibRelative $libFile
 	}
 }
@@ -213,9 +217,7 @@ namespace export add_lib_relative
 # @param files		List containing the file paths within the library directory
 # @param lib		VHDL library to copile files into (optional, default is <ip_name>_<ip_version>)
 #					"NONE" can be used to compile the files into the default library.
-# @param type		Vivado file type (common values "VHDL" or "VHDL 2008". If "NONE" is passed, vivado detects
-#					file type automatically. However, for VHDL 2008 this option must be used explicitly (vivado
-#					auto detection fails).
+# @param type		Override file type detected by vivado automatically. For VHDL, VHDL 2008 is used by default.
 proc add_lib_copied {tgtPath libPath files {lib "NONE"} {type "NONE"}} {
 	variable LibCopied
 	variable DefaultVhdlLib
@@ -228,7 +230,11 @@ proc add_lib_copied {tgtPath libPath files {lib "NONE"} {type "NONE"}} {
 		} else {
 			dict set copied LIBRARY $lib
 		}
+		#Use VHDL 2008 as default for all VHDL files
 		dict set copied TYPE $type
+		if {([string match "*.vhdl" $file] || [string match "*.vhd" $file]) && ($type == "NONE")} {
+			dict set copied TYPE "VHDL 2008"
+		}
 		lappend LibCopied $copied
 	}
 }


### PR DESCRIPTION
I added the option to choose the Vivado file type manually (in case Vivado detects it wrongly).

Additionally the scrtipts use "VHDL 2008" file type for all \*.vhd and \*.vhdl files. Vivado uses VHDL 2002 by default which is quite restrictive. VHDL 2008 does not have any drawbacks, so we can use it as default.

This pull request resolves #5