### PR TITLE
BUGFIX: Catch error in set_msg_config introduced by Vivado 2020.1

### DIFF
--- a/IpPackage2017_2_1.tcl
+++ b/IpPackage2017_2_1.tcl
@@ -676,7 +676,7 @@ proc package {tgtDir {edit false} {synth false} {part ""}} {
 	variable DefaultVhdlLib
 	puts "*** Set IP properties ***"
 	#Having unreferenced files is not allowed (leads to problems in the script). Therefore the warning is promoted to an error.
-	set_msg_config -id  {[IP_Flow 19-3833]} -new_severity "ERROR"
+	catch {set_msg_config -id  {[IP_Flow 19-3833]} -new_severity "ERROR"}
 	ipx::package_project -root_dir $tgtDir -taxonomy /UserIP
     set OldXguiFile [concat $tgtDir/xgui/[get_property name [ipx::current_core]]_v[string map {. _} [get_property version [ipx::current_core]]].tcl]
 	set_property vendor $IpVendorShort [ipx::current_core]


### PR DESCRIPTION
Vivado 2020.1 crashes on set_msg_config if the same rule already exists. This is a bug of Vivado (only a warning is expected in this case) but I guess most likely it won't be fixed by Xilinx.