### PR TITLE
Add functionality to add the Taxonomy

### DIFF
--- a/CommandRef.md
+++ b/CommandRef.md
@@ -20,6 +20,7 @@ namespace import psi::ip_package::latest::*
  * [set_vendor_url](#set_vendor_url)
  * [set_logo_relative](#set_logo_relative) 
  * [set_datasheet_relative](#set_datasheet_relative)
+ * [set_taxonomy](#set_taxonomy)
  * [set_top_entity](#set_top_entity)
  * [add_sources_relative](#add_sources_relative) 
  * [add_lib_relative](#add_lib_relative) 
@@ -252,6 +253,38 @@ Add a Datasheet to the IP-Core. The datasheet is not copied into the IP-Core but
       <td> datasheet </td>
       <td> No </td>
       <td> Path to the datasheet. </td>
+    </tr>
+</table>
+
+### set_taxonomy
+**Usage**
+
+```
+set_taxonomy <groups>
+```
+
+**Example**
+
+```
+set_taxonomy {/AXI_Infrastructure /Communication_&_Networking/Ethernet /my_new_group}
+```
+
+**Description**
+
+A custom taxonomy (display grouping in the IP Catalog) can be added by this command. Each IP can be represented in one or multiple groups. The command expects a list of groups as parameter. Groups can be split into sub-groups by using a "file" like structure */main_group/sub_group*. Unknown groups are automatically created by Vivado.
+
+**Parameters**
+
+<table>
+    <tr>
+      <th width="200"><b>Parameter</b></th>
+      <th align="center" width="80"><b>Optional</b></th>
+      <th align="right"><b>Description</b></th>
+    </tr>
+    <tr>
+      <td> taxonomy </td>
+      <td> No </td>
+      <td> List of taxonomy groups. </td>
     </tr>
 </table>
 

--- a/IpPackage2017_2_1.tcl
+++ b/IpPackage2017_2_1.tcl
@@ -26,6 +26,7 @@ variable IpVendorShort
 variable IpVendorUrl
 variable IpDescription
 variable IpTargetLanguage
+variable IpTaxonomy
 variable SrcRelative
 variable LibRelative
 variable LibCopied
@@ -76,6 +77,7 @@ proc init {name version revision library} {
 	variable IpVersionUnderscore [string map {. _} $version]
     variable IpDescription
     variable IpTargetLanguage "VHDL"
+	variable IpTaxonomy {{"/UserIP "}}
 	variable SrcRelative [list]
 	variable LibRelative [list]
 	variable LibCopied [list]
@@ -143,6 +145,14 @@ proc set_vendor_url {url} {
 	variable IpVendorUrl $url
 }
 namespace export set_vendor_url
+
+# Set the taxonomy of the IP-Core
+#
+# @param taxonomy   List of categories
+proc set_taxonomy {taxonomy} {
+	variable IpTaxonomy $taxonomy
+}
+namespace export set_taxonomy
 
 # Set the name of the top-entity (only required if Vivado cannot determine the top entity automatically)
 #
@@ -710,12 +720,13 @@ proc package {tgtDir {edit false} {synth false} {part ""}} {
 	variable IpVendor
 	variable IpVendorShort
 	variable IpVendorUrl
+	variable IpTaxonomy
     variable IpTargetLanguage
 	variable DefaultVhdlLib
 	puts "*** Set IP properties ***"
 	#Having unreferenced files is not allowed (leads to problems in the script). Therefore the warning is promoted to an error.
 	catch {set_msg_config -id  {[IP_Flow 19-3833]} -new_severity "ERROR"}
-	ipx::package_project -root_dir $tgtDir -taxonomy /UserIP
+	ipx::package_project -root_dir $tgtDir -taxonomy $IpTaxonomy
     set OldXguiFile [concat $tgtDir/xgui/[get_property name [ipx::current_core]]_v[string map {. _} [get_property version [ipx::current_core]]].tcl]
 	set_property vendor $IpVendorShort [ipx::current_core]
 	set_property name $IpName [ipx::current_core]
@@ -765,7 +776,7 @@ proc package {tgtDir {edit false} {synth false} {part ""}} {
 	
 	#GUI Initialize (remove auto-generate stuff)
 	ipgui::remove_page -component [ipx::current_core] [ipgui::get_pagespec -name "Page 0" -component [ipx::current_core]]
-	
+
 	#Add Pages
 	puts "*** Add GUI pages ***"
 	variable GuiPages

--- a/README.md
+++ b/README.md
@@ -53,12 +53,13 @@ set IP_NAME data_rec
 set IP_VERSION 1.0
 set IP_REVISION "auto"
 set IP_LIBRARY GPAC3
-set IP_DESCIRPTION "Mutli channel data recorder (supports pre-trigger and self-triggering)"
+set IP_DESCIRPTION "Multi channel data recorder (supports pre-trigger and self-triggering)"
 
 init $IP_NAME $IP_VERSION $IP_REVISION $IP_LIBRARY
 set_description $IP_DESCIRPTION
 set_logo_relative "../doc/psi_logo_150.gif"
 set_datasheet_relative "../doc/$IP_NAME.pdf"
+set_taxonomy {/AXI_Infrastructure /Communication_&_Networking/Ethernet}
 
 ###############################################################
 # Add Source Files


### PR DESCRIPTION
While packaging an IP can be assigned to several groups.
This "Taxonomy" can now be set by the command "set_taxonomy".

(I added a line to the README.md, please change this to categories that matches better to the example IP)