### PR TITLE
Add function to add sub cores to the IP

### DIFF
--- a/CommandRef.md
+++ b/CommandRef.md
@@ -24,6 +24,7 @@ namespace import psi::ip_package::latest::*
  * [add_sources_relative](#add_sources_relative) 
  * [add_lib_relative](#add_lib_relative) 
  * [add_lib_copied](#add_lib_copied) 
+ * [add_sub_core_reference](#add_sub_core_reference)
  * [add_ttcl_vhd](#add_ttcl_vhd)
  * [gui_add_page](#gui_add_page) 
  * [gui_add_group](#gui_add_group)
@@ -416,6 +417,39 @@ By default the file type is determined by Vivado automatically but the auto dete
       <td> type </td>
       <td> Yes </td>
       <td> Vivado file type. By default, the file type is detected automatically. Automatic detection can also be achieved by passing "NONE". </td>
+    </tr>
+</table>
+
+### add_sub_core_reference
+**Usage**
+
+```
+add_sub_core_reference {<Subcore VLNV>}
+```
+
+**Example**
+
+```
+add_sub_core_reference {
+        xilinx.com:ip:axis_switch:1.1 \
+}
+```
+
+**Description**
+
+Add one or more sub core references to the IP-Core. Use the VLNV nameing to identify the cores. Note: Not all IP from the repositories can be selected. Check with the IP-Packager which IP are supported.
+
+**Parameters**
+<table>
+    <tr>
+      <th width="200"><b>Parameter</b></th>
+      <th align="center" width="80"><b>Optional</b></th>
+      <th align="right"><b>Description</b></th>
+    </tr>
+    <tr>
+      <td> cores </td>
+      <td> No </td>
+      <td> List of VLNV to add to the IP-Core </td>
     </tr>
 </table>
 

--- a/IpPackage2017_2_1.tcl
+++ b/IpPackage2017_2_1.tcl
@@ -53,6 +53,7 @@ variable DefaultVhdlLib
 variable GuiSupportTcl
 variable TtclFiles
 variable RemoveFiles
+variable SubCores
 
 # Initialize IP Packaging process
 #
@@ -101,6 +102,7 @@ proc init {name version revision library} {
 	variable GuiSupportTcl [list]
 	variable TtclFiles [list]
 	variable RemoveFiles [list]
+    variable SubCores [list]
 }
 namespace export init
 
@@ -194,6 +196,15 @@ proc add_sources_relative {srcs {lib "NONE"} {type "NONE"}} {
 	}
 }
 namespace export add_sources_relative
+
+# Add sub core reference
+#
+# @param cores       List containing the sub cores to be added to the project.
+proc add_sub_core_reference {cores} {
+	variable SubCores
+	lappend SubCores $cores
+}
+namespace export add_sub_core_reference
 
 # Add SW driver files that are referenced to relatively
 #
@@ -762,6 +773,16 @@ proc package {tgtDir {edit false} {synth false} {part ""}} {
 	puts "*** Add IP Location ***"
     set_property  ip_repo_paths  $tgtDir [current_project]
     update_ip_catalog
+
+    # Add references to sub-cores
+    puts "*** Add references to sub-cores***"
+    variable SubCores
+    foreach core $SubCores {
+        puts [string trim $core]
+        ipx::add_subcore [string trim $core] [ipx::get_file_groups xilinx_anylanguagesynthesis -of_objects [ipx::current_core]]
+        ipx::add_subcore [string trim $core] [ipx::get_file_groups xilinx_anylanguagebehavioralsimulation -of_objects [ipx::current_core]]
+    }
+    ipx::merge_project_changes files [ipx::current_core]
 	
 	#GUI Initialize (remove auto-generate stuff)
 	ipgui::remove_page -component [ipx::current_core] [ipgui::get_pagespec -name "Page 0" -component [ipx::current_core]]
@@ -772,7 +793,7 @@ proc package {tgtDir {edit false} {synth false} {part ""}} {
 	foreach page $GuiPages {
 		ipgui::add_page -name "$page" -component [ipx::current_core] -display_name "$page"
 	}
-	
+
 	#Handle Parameters
 	variable GuiParameters
 	puts "*** Define GUI parameters ***"


### PR DESCRIPTION
Adding sub cores allows to add existing IPs into the packaged IP.

**Usage**

```
add_sub_core_reference {<Subcore VLNV>}
```

**Example**

```
add_sub_core_reference {
        xilinx.com:ip:axis_switch:1.1 \
}
```

**Description**

Add one or more sub core references to the IP-Core. Use the VLNV nameing to identify the cores. Note: Not all IP from the repositories can be selected. Check with the IP-Packager which IP are supported.

**Parameters**
<table>
    <tr>
      <th width="200"><b>Parameter</b></th>
      <th align="center" width="80"><b>Optional</b></th>
      <th align="right"><b>Description</b></th>
    </tr>
    <tr>
      <td> cores </td>
      <td> No </td>
      <td> List of VLNV to add to the IP-Core </td>
    </tr>
</table>