### PR TITLE
Fix representation of add_xparameter documentation

### DIFF
--- a/CommandRef.md
+++ b/CommandRef.md
@@ -1123,6 +1123,7 @@ The driver sources must be located in the folder *DRIVER_MAIN/src* due to Limita
       <td> List of driver source files (relative to *dir*) </td>
     </tr>
 </table>
+
 ### add_xparameters_entry
 
 **Usage**


### PR DESCRIPTION
The header of the add_xparameters_entry is not rendered correctly. 
Added a new line in front of the add_xparameters_entry header to fix this.