### PR TITLE
Adding the posibility to hash the source

### DIFF
--- a/CommandRef.md
+++ b/CommandRef.md
@@ -88,8 +88,9 @@ in every packaging script.
       <td> No </td>
       <td> Revision of the IP-core. Alternative to passing a number, the string "auto" can be passed. In this
            case the UNIX timestamp of the build time is taken as revision which results in an automatically
-           updated and unique revision number. As a result, Vivado detects a new revision every time time
-		   IP core is packaged. </td>
+           updated and unique revision number. As a result, Vivado detects a new revision every time the
+		   IP core is packaged. With the string "hash" the revision number is generated as a hash from the
+		   source. This allows to rerun the script without any change of the revision number unless the script was modified.</td>
     </tr>		
 </table>
 

--- a/IpPackage2017_2_1.tcl
+++ b/IpPackage2017_2_1.tcl
@@ -9,6 +9,7 @@
 ####################################################################
 
 #Dependencies
+package require md5
 variable fileLoc [file normalize [file dirname [info script]]]
 source $fileLoc/PsiUtilPath.tcl
 source $fileLoc/PsiUtilString.tcl
@@ -57,8 +58,9 @@ variable RemoveFiles
 # Initialize IP Packaging process
 #
 # @param name 		Name of the IP-Core (e.g. "My new IP Core")
-# @param version 	Version of the IP-Core (e.g. 1.0), pass "auto" for using the timestamp
+# @param version 	Version of the IP-Core (e.g. 1.0)
 # @param revision	Revision of the IP-Core (e.g. 12)
+#                   Pass "auto" for using the timestamp or "hash" for using a hash of the source script.
 # @param library	Library the IP-Core is compiled into (e.g. GPAC3)
 proc init {name version revision library} {
 	variable IpVersion $version
@@ -66,6 +68,9 @@ proc init {name version revision library} {
 	variable IpName [string map {\  _} $IpDispName]
 	if {$revision=="auto"} {
 		variable IpRevision [clock seconds]
+	} elseif {$revision=="hash"} {
+	    variable IpRevision [string range [expr 0x[md5::md5 -hex -file "$::argv0"]] 0 5]
+	    puts $IpRevision
 	} else {
 		variable IpRevision $revision
 	}	


### PR DESCRIPTION
The revision could be set constant or as a timestamp. With this commit
the possibility to hash the source script and use this as revision is
added. This allows to reproduce the same revision as long as the source
script is not modified.